### PR TITLE
docs: Add detailed data model documentation

### DIFF
--- a/docs/water_system/README.md
+++ b/docs/water_system/README.md
@@ -55,35 +55,23 @@
 *   **[27_control_examples.md](./27_control_examples.md)**
 *   **[28_testing_examples.md](./28_testing_examples.md)**
 
+## 数据模型 (Data Models)
+
+这部分文档深入到数据持久层，为每个核心模块提供了推荐的数据表结构或时序数据模型。
+
+*   **[./data_models/01_simulation_datamodel.md](./data_models/01_simulation_datamodel.md)**
+*   **[./data_models/02_identification_datamodel.md](./data_models/02_identification_datamodel.md)**
+*   **[./data_models/03_twinning_datamodel.md](./data_models/03_twinning_datamodel.md)**
+*   **[./data_models/04_diagnosis_datamodel.md](./data_models/04_diagnosis_datamodel.md)**
+*   **[./data_models/05_evaluation_datamodel.md](./data_models/05_evaluation_datamodel.md)**
+*   **[./data_models/06_prediction_datamodel.md](./data_models/06_prediction_datamodel.md)**
+*   **[./data_models/07_scheduling_datamodel.md](./data_models/07_scheduling_datamodel.md)**
+*   **[./data_models/08_testing_datamodel.md](./data_models/08_testing_datamodel.md)**
+
 ## 文件列表
 
 *   `00_overview.md`
 *   `01_simulation_object.md`
-*   `02_simulation_methods.md`
-*   `03_identification_object.md`
-*   `04_identification_methods.md`
-*   `05_twinning_object.md`
-*   `06_twinning_methods.md`
-*   `07_diagnosis_object.md`
-*   `08_diagnosis_methods.md`
-*   `09_evaluation_object.md`
-*   `10_evaluation_methods.md`
-*   `11_prediction_object.md`
-*   `12_prediction_methods.md`
-*   `13_scheduling_object.md`
-*   `14_scheduling_methods.md`
-*   `15_control_object.md`
-*   `16_control_methods.md`
-*   `17_testing_object.md`
-*   `18_testing_methods.md`
-*   `19_integration.md`
-*   `20_simulation_examples.md`
-*   `21_identification_examples.md`
-*   `22_twinning_examples.md`
-*   `23_diagnosis_examples.md`
-*   `24_evaluation_examples.md`
-*   `25_prediction_examples.md`
-*   `26_scheduling_examples.md`
-*   `27_control_examples.md`
-*   `28_testing_examples.md`
+*   ... (and 27 more files)
+*   `data_models/` (目录)
 *   `README.md` (本文件)

--- a/docs/water_system/data_models/01_simulation_datamodel.md
+++ b/docs/water_system/data_models/01_simulation_datamodel.md
@@ -1,0 +1,149 @@
+# 1. 仿真 (Simulation) - 数据模型
+
+本篇文档详细描述了与“仿真”功能相关的核心数据模型。我们采用关系型数据库模型来存储仿真的配置和管网拓扑结构。
+
+## ER图 (实体关系图)
+
+```
+[simulations] 1--1 [networks]
+[networks] 1--* [nodes]
+[networks] 1--* [pipes]
+[networks] 1--* [pumps]
+[networks] 1--* [valves]
+[networks] 1--* [reservoirs]
+```
+
+## 表结构定义 (SQL DDL)
+
+### `simulations`
+
+存储仿真任务的基本信息和配置。
+
+```sql
+CREATE TABLE simulations (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    network_id VARCHAR(255) NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    time_step_seconds INTEGER NOT NULL,
+    status VARCHAR(50) DEFAULT 'created',
+    solver_options JSONB, -- 存储求解器配置, e.g., {"tolerance": 1e-6}
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (network_id) REFERENCES networks(id)
+);
+```
+
+### `networks`
+
+存储管网的元数据。
+
+```sql
+CREATE TABLE networks (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    source_file_path VARCHAR(1024), -- 可选，如果从INP等文件导入
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `nodes` (节点)
+
+存储管网中的节点信息，如接点、需用水户。
+
+```sql
+CREATE TABLE nodes (
+    id VARCHAR(255) PRIMARY KEY,
+    network_id VARCHAR(255) NOT NULL,
+    base_demand_m3_per_sec NUMERIC,
+    elevation_m NUMERIC,
+    initial_quality NUMERIC,
+    demand_pattern_id VARCHAR(255), -- 关联到需用水量模式
+    coordinates JSONB, -- e.g., {"x": 123.45, "y": 678.90}
+    FOREIGN KEY (network_id) REFERENCES networks(id)
+);
+```
+
+### `pipes` (管道)
+
+```sql
+CREATE TABLE pipes (
+    id VARCHAR(255) PRIMARY KEY,
+    network_id VARCHAR(255) NOT NULL,
+    from_node_id VARCHAR(255) NOT NULL,
+    to_node_id VARCHAR(255) NOT NULL,
+    length_m NUMERIC NOT NULL,
+    diameter_m NUMERIC NOT NULL,
+    roughness NUMERIC NOT NULL, -- e.g., Hazen-Williams C-factor
+    status VARCHAR(50) DEFAULT 'Open', -- Open, Closed, CV
+    FOREIGN KEY (network_id) REFERENCES networks(id),
+    FOREIGN KEY (from_node_id) REFERENCES nodes(id),
+    FOREIGN KEY (to_node_id) REFERENCES nodes(id)
+);
+```
+
+### `pumps` (水泵)
+
+```sql
+CREATE TABLE pumps (
+    id VARCHAR(255) PRIMARY KEY, -- 注意: 水泵也是一个管段，其ID应与pipes表中的ID对应
+    network_id VARCHAR(255) NOT NULL,
+    pump_curve_id VARCHAR(255), -- 关联到水泵特性曲线
+    initial_status VARCHAR(50) DEFAULT 'Open',
+    initial_speed NUMERIC DEFAULT 1.0,
+    power_kw NUMERIC,
+    FOREIGN KEY (id) REFERENCES pipes(id),
+    FOREIGN KEY (network_id) REFERENCES networks(id)
+);
+```
+
+### `valves` (阀门)
+
+```sql
+CREATE TABLE valves (
+    id VARCHAR(255) PRIMARY KEY, -- 阀门也是一个管段
+    network_id VARCHAR(255) NOT NULL,
+    valve_type VARCHAR(50) NOT NULL, -- e.g., PRV, PSV, FCV
+    diameter_m NUMERIC NOT NULL,
+    initial_setting NUMERIC,
+    initial_status VARCHAR(50) DEFAULT 'Open',
+    FOREIGN KEY (id) REFERENCES pipes(id),
+    FOREIGN KEY (network_id) REFERENCES networks(id)
+);
+```
+
+### `reservoirs` (水库/水池)
+
+```sql
+CREATE TABLE reservoirs (
+    id VARCHAR(255) PRIMARY KEY, -- 水库是一个特殊的节点
+    network_id VARCHAR(255) NOT NULL,
+    initial_level_m NUMERIC,
+    min_level_m NUMERIC,
+    max_level_m NUMERIC,
+    diameter_m NUMERIC,
+    FOREIGN KEY (id) REFERENCES nodes(id),
+    FOREIGN KEY (network_id) REFERENCES networks(id)
+);
+```
+
+### 仿真结果 (非关系型存储)
+
+仿真结果是大量的时序数据，通常不适合存储在关系型数据库中。推荐使用 **时序数据库 (Time-Series Database)**，如 InfluxDB 或 TimescaleDB。
+
+数据模型示例如下 (以InfluxDB Line Protocol为例):
+
+```
+# Measurement: pressure
+# Tags: simulation_id, node_id
+# Fields: value
+pressure,simulation_id=sim_abc,node_id=n1 value=25.3 1678886400000000000
+pressure,simulation_id=sim_abc,node_id=n2 value=24.9 1678886400000000000
+
+# Measurement: flow
+# Tags: simulation_id, pipe_id
+# Fields: value
+flow,simulation_id=sim_abc,pipe_id=p1 value=105.7 1678886400000000000
+```

--- a/docs/water_system/data_models/02_identification_datamodel.md
+++ b/docs/water_system/data_models/02_identification_datamodel.md
@@ -1,0 +1,83 @@
+# 2. 辨识 (Identification) - 数据模型
+
+本篇文档详细描述了与“参数辨识”功能相关的核心数据模型。
+
+## ER图 (实体关系图)
+
+```
+[identification_tasks] 1--* [identification_parameters]
+[identification_tasks] 1--* [observation_data_points]
+[identification_tasks] 1--1 [identification_results]
+```
+
+## 表结构定义 (SQL DDL)
+
+### `identification_tasks`
+
+存储辨识任务的基本信息和配置。
+
+```sql
+CREATE TABLE identification_tasks (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    simulation_model_id VARCHAR(255) NOT NULL, -- 关联的基础仿真模型
+    optimizer_options JSONB, -- e.g., {"algorithm": "genetic_algorithm", "population_size": 50}
+    status VARCHAR(50) DEFAULT 'created',
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (simulation_model_id) REFERENCES simulations(id)
+);
+```
+
+### `identification_parameters`
+
+定义了在一个辨识任务中，具体要调整哪些参数。
+
+```sql
+CREATE TABLE identification_parameters (
+    id SERIAL PRIMARY KEY,
+    task_id VARCHAR(255) NOT NULL,
+    element_type VARCHAR(50) NOT NULL, -- e.g., 'pipe', 'node'
+    element_id VARCHAR(255) NOT NULL,
+    parameter_name VARCHAR(100) NOT NULL, -- e.g., 'roughness', 'demand_multiplier'
+    initial_guess NUMERIC,
+    lower_bound NUMERIC,
+    upper_bound NUMERIC,
+    FOREIGN KEY (task_id) REFERENCES identification_tasks(id)
+);
+```
+
+### `observation_data_points`
+
+存储用于辨识的观测数据。对于大规模或高频率的观测，可考虑使用时序数据库。此处的模型适用于批处理辨识任务。
+
+```sql
+CREATE TABLE observation_data_points (
+    id BIGSERIAL PRIMARY KEY,
+    task_id VARCHAR(255) NOT NULL,
+    observation_time TIMESTAMPTZ NOT NULL,
+    element_type VARCHAR(50) NOT NULL, -- e.g., 'node', 'pipe'
+    element_id VARCHAR(255) NOT NULL,
+    parameter_name VARCHAR(100) NOT NULL, -- e.g., 'pressure', 'flow'
+    observed_value NUMERIC NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES identification_tasks(id)
+);
+
+-- 为了提高查询效率，建议在(task_id, observation_time)上创建索引
+CREATE INDEX idx_obs_data_task_time ON observation_data_points (task_id, observation_time);
+```
+
+### `identification_results`
+
+存储辨识任务完成后的结果。
+
+```sql
+CREATE TABLE identification_results (
+    task_id VARCHAR(255) PRIMARY KEY,
+    status VARCHAR(50) NOT NULL, -- 'completed' or 'failed'
+    completed_at TIMESTAMPTZ,
+    final_objective_value NUMERIC, -- 最终的目标函数值，表示拟合优度
+    identified_parameters JSONB, -- 存储最终辨识出的参数值, e.g., [{"element_id": "p1", "parameter_name": "roughness", "optimal_value": 125.8}]
+    convergence_history JSONB, -- 存储收敛过程，可选
+    FOREIGN KEY (task_id) REFERENCES identification_tasks(id)
+);
+```

--- a/docs/water_system/data_models/03_twinning_datamodel.md
+++ b/docs/water_system/data_models/03_twinning_datamodel.md
@@ -1,0 +1,109 @@
+# 3. 孪生 (Twinning) - 数据模型
+
+本篇文档详细描述了与“数字孪生”功能相关的核心数据模型。数字孪生的数据模型是整个系统的核心，它分为两部分：
+1.  **配置数据**: 存储孪生本身的定义和策略，适合用关系型数据库。
+2.  **状态数据**: 存储孪生在每个时间点的状态快照，数据量巨大，是典型的时序数据，适合用时序数据库。
+
+---
+
+## 第一部分: 配置数据 (关系型模型)
+
+### `digital_twins`
+
+存储数字孪生服务实例的元数据和配置。
+
+```sql
+CREATE TABLE digital_twins (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    base_simulation_model_id VARCHAR(255) NOT NULL,
+    status VARCHAR(50) DEFAULT 'stopped', -- 'running', 'stopped', 'degraded'
+    synchronization_policy JSONB, -- 存储同步策略, e.g., {"sync_interval_seconds": 60, ...}
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (base_simulation_model_id) REFERENCES simulations(id)
+);
+```
+
+### `data_source_connections`
+
+存储孪生体与外部数据源（如SCADA）的连接信息。
+
+```sql
+CREATE TABLE data_source_connections (
+    id VARCHAR(255) PRIMARY KEY,
+    twin_id VARCHAR(255) NOT NULL,
+    source_type VARCHAR(100) NOT NULL, -- 'opc_ua', 'modbus_tcp', 'mqtt'
+    endpoint_url VARCHAR(1024) NOT NULL,
+    credentials JSONB, -- 存储认证信息
+    is_active BOOLEAN DEFAULT TRUE,
+    FOREIGN KEY (twin_id) REFERENCES digital_twins(id)
+);
+```
+
+### `data_point_mappings`
+
+定义了外部数据源中的具体测点如何映射到管网模型中的元素和属性。
+
+```sql
+CREATE TABLE data_point_mappings (
+    id SERIAL PRIMARY KEY,
+    connection_id VARCHAR(255) NOT NULL,
+    source_tag VARCHAR(255) NOT NULL, -- SCADA中的点位名, e.g., "SCADA.Node.Pressure.N5"
+    element_type VARCHAR(50) NOT NULL, -- 'node', 'pipe', etc.
+    element_id VARCHAR(255) NOT NULL,
+    parameter_name VARCHAR(100) NOT NULL, -- 'pressure', 'flow', etc.
+    UNIQUE (connection_id, source_tag),
+    FOREIGN KEY (connection_id) REFERENCES data_source_connections(id)
+);
+```
+
+---
+
+## 第二部分: 状态数据 (时序模型)
+
+这部分数据强烈建议使用专门的时序数据库（Time-Series Database, TSDB）如 InfluxDB, TimescaleDB, 或 Prometheus 进行存储。下面以 **InfluxDB** 的数据模型为例。
+
+在InfluxDB中，我们会为每一种类型的测量值创建一个`measurement`。
+
+### `state_pressure` (节点压力)
+
+*   **Measurement:** `state_pressure`
+*   **Tags:**
+    *   `twin_id`: 孪生实例的ID。
+    *   `node_id`: 节点的ID。
+*   **Fields:**
+    *   `value`: 压力值 (Float)。
+    *   `quality_score`: 数据质量评分 (Float, 0-1)。
+*   **示例 (Line Protocol):**
+    ```
+    state_pressure,twin_id=twin_main,node_id=n5 value=25.3,quality_score=0.98 1678886400000000000
+    ```
+
+### `state_flow` (管道流量)
+
+*   **Measurement:** `state_flow`
+*   **Tags:**
+    *   `twin_id`: 孪生实例的ID。
+    *   `pipe_id`: 管道的ID。
+*   **Fields:**
+    *   `value`: 流量值 (Float)。
+    *   `quality_score`: 数据质量评分 (Float, 0-1)。
+*   **示例 (Line Protocol):**
+    ```
+    state_flow,twin_id=twin_main,pipe_id=p3 value=0.45,quality_score=0.95 1678886400000000000
+    ```
+
+### `state_quality` (水质)
+
+*   **Measurement:** `state_quality`
+*   **Tags:**
+    *   `twin_id`: 孪生实例的ID。
+    *   `node_id`: 节点的ID。
+    *   `pollutant`: 污染物名称 (e.g., "chlorine", "turbidity")。
+*   **Fields:**
+    *   `value`: 浓度或值 (Float)。
+    *   `quality_score`: 数据质量评分 (Float, 0-1)。
+*   **示例 (Line Protocol):**
+    ```
+    state_quality,twin_id=twin_main,node_id=n10,pollutant=chlorine value=0.85,quality_score=0.99 1678886400000000000
+    ```

--- a/docs/water_system/data_models/04_diagnosis_datamodel.md
+++ b/docs/water_system/data_models/04_diagnosis_datamodel.md
@@ -1,0 +1,82 @@
+# 4. 诊断 (Diagnosis) - 数据模型
+
+本篇文档详细描述了与“故障诊断”功能相关的核心数据模型。该模型主要围绕“诊断规则”的定义和“告警事件”的记录与管理。
+
+## ER图 (实体关系图)
+
+```
+[diagnosis_services] 1--* [diagnosis_rules]
+[diagnosis_rules] 1--* [diagnosis_alarms]
+```
+*(注: `diagnosis_services` 表用于管理不同的诊断任务，为简化起见，我们在此关注规则和告警本身)。*
+
+## 表结构定义 (SQL DDL)
+
+### `diagnosis_rules`
+
+存储用于定义异常或故障模式的规则。
+
+```sql
+CREATE TABLE diagnosis_rules (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    severity VARCHAR(50) NOT NULL, -- 'critical', 'warning', 'info'
+
+    -- 规则的触发条件可以有多种形式，使用JSONB可以灵活存储
+    -- 示例1: 表达式类型
+    -- {"type": "expression", "expression": "delta(node.n5.pressure, 5min) < -10"}
+    -- 示例2: 机器学习模型类型
+    -- {"type": "ml_model", "model_id": "chlorine_anomaly_detector_v1"}
+    trigger_condition JSONB NOT NULL,
+
+    -- 建议的应对措施
+    suggested_actions TEXT[],
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `diagnosis_alarms`
+
+记录所有由诊断规则触发的告警事件。这张表同时包含了活动告警和历史告警。
+
+```sql
+CREATE TABLE diagnosis_alarms (
+    id BIGSERIAL PRIMARY KEY,
+    rule_id VARCHAR(255) NOT NULL,
+
+    -- 告警状态 (Lifecycle of an alarm)
+    -- unacknowledged -> acknowledged -> resolved
+    status VARCHAR(50) NOT NULL DEFAULT 'unacknowledged',
+
+    -- 触发信息
+    triggered_at TIMESTAMPTZ NOT NULL,
+    severity_at_trigger VARCHAR(50) NOT NULL,
+    conclusion_at_trigger TEXT NOT NULL,
+    triggering_details JSONB, -- 存储触发时相关的具体数值
+
+    -- 确认信息 (Acknowledgement)
+    acknowledged_at TIMESTAMPTZ,
+    acknowledged_by VARCHAR(255), -- User ID or name
+    acknowledgement_comments TEXT,
+
+    -- 解决信息 (Resolution)
+    resolved_at TIMESTAMPTZ,
+    resolved_by VARCHAR(255), -- User ID or name
+    resolution_notes TEXT,
+
+    FOREIGN KEY (rule_id) REFERENCES diagnosis_rules(id)
+);
+
+-- 为了高效查询活动告警和历史告警，创建索引
+CREATE INDEX idx_alarms_status ON diagnosis_alarms (status);
+CREATE INDEX idx_alarms_triggered_at ON diagnosis_alarms (triggered_at);
+```
+
+### 设计说明
+
+*   **规则的灵活性**: 在 `diagnosis_rules` 表中，`trigger_condition` 字段使用 `JSONB` 类型，这提供了极大的灵活性。无论是简单的阈值规则、复杂的布尔逻辑表达式，还是调用外部机器学习模型的指令，都可以被结构化地存储。
+*   **告警生命周期**: `diagnosis_alarms` 表通过 `status` 字段清晰地管理了每个告警从发生 (`unacknowledged`)、被响应 (`acknowledged`) 到被关闭 (`resolved`) 的完整生命周期。所有的时间戳和用户信息都被记录下来，便于审计和责任追溯。
+*   **性能**: 对 `status` 和 `triggered_at` 字段建立索引，可以极大地提高查询效率。例如，查询“所有活动的严重告警”或“上周发生的所有告警”等常见操作，都会因此受益。

--- a/docs/water_system/data_models/05_evaluation_datamodel.md
+++ b/docs/water_system/data_models/05_evaluation_datamodel.md
@@ -1,0 +1,102 @@
+# 5. 评价 (Evaluation) - 数据模型
+
+本篇文档详细描述了与“性能评价”功能相关的核心数据模型。该模型的核心是围绕可复用的“KPI定义”和周期性生成的“评价报告”。
+
+## ER图 (实体关系图)
+
+```
+[evaluation_tasks] 1--* [evaluation_reports]
+[evaluation_reports] 1--* [evaluation_report_kpis]
+[kpi_definitions] 1--* [evaluation_report_kpis]
+```
+
+## 表结构定义 (SQL DDL)
+
+### `evaluation_tasks`
+
+存储周期性评价任务的配置信息。
+
+```sql
+CREATE TABLE evaluation_tasks (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    target_twin_id VARCHAR(255) NOT NULL,
+
+    -- e.g., {"type": "recurring", "cron_expression": "0 0 1 * *"}
+    evaluation_period JSONB NOT NULL,
+
+    -- 该评价任务包含的KPI列表
+    kpi_ids VARCHAR(255)[], -- Array of kpi_definition IDs
+
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (target_twin_id) REFERENCES digital_twins(id)
+);
+```
+
+### `kpi_definitions`
+
+定义了系统中的关键性能指标 (KPI)。这使得KPI的定义标准化、可复用。
+
+```sql
+CREATE TABLE kpi_definitions (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    unit VARCHAR(50), -- e.g., '%', 'mH2O', 'kWh/t·hm'
+
+    -- KPI的计算方法，使用JSONB可以非常灵活
+    -- e.g., {"type": "average", "source": "twin_history.node_states.*.pressure"}
+    -- e.g., {"type": "expression", "expression": "(sum(inflow) - sum(outflow))/sum(inflow)"}
+    -- e.g., {"type": "custom_function", "function_name": "calculate_pump_whc"}
+    calculation_method JSONB NOT NULL,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `evaluation_reports`
+
+存储每一次评价任务执行后生成的报告。
+
+```sql
+CREATE TABLE evaluation_reports (
+    id BIGSERIAL PRIMARY KEY,
+    task_id VARCHAR(255) NOT NULL,
+
+    -- 本次报告所评估的数据时间范围
+    data_start_time TIMESTAMPTZ NOT NULL,
+    data_end_time TIMESTAMPTZ NOT NULL,
+
+    -- 报告生成信息
+    generated_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(50) NOT NULL, -- 'success', 'failed'
+    summary TEXT, -- 报告的文字总结
+
+    FOREIGN KEY (task_id) REFERENCES evaluation_tasks(id)
+);
+```
+
+### `evaluation_report_kpis`
+
+存储在每份报告中，每个KPI的具体计算结果。
+
+```sql
+CREATE TABLE evaluation_report_kpis (
+    id BIGSERIAL PRIMARY KEY,
+    report_id BIGINT NOT NULL,
+    kpi_id VARCHAR(255) NOT NULL,
+
+    calculated_value NUMERIC,
+
+    -- 与上一个周期的对比值，可以是差值或百分比
+    trend_from_previous NUMERIC,
+
+    -- 其他相关的元数据
+    metadata JSONB,
+
+    FOREIGN KEY (report_id) REFERENCES evaluation_reports(id),
+    FOREIGN KEY (kpi_id) REFERENCES kpi_definitions(id),
+    UNIQUE (report_id, kpi_id)
+);
+```

--- a/docs/water_system/data_models/06_prediction_datamodel.md
+++ b/docs/water_system/data_models/06_prediction_datamodel.md
@@ -1,0 +1,85 @@
+# 6. 预测 (Prediction) - 数据模型
+
+本篇文档详细描述了与“预测”功能相关的核心数据模型。与数字孪生类似，预测功能的数据也分为两部分：
+1.  **配置数据**: 存储预测任务的定义，适合用关系型数据库。
+2.  **结果数据**: 存储预测生成的时序结果，适合用时序数据库。
+
+---
+
+## 第一部分: 配置数据 (关系型模型)
+
+### `prediction_tasks`
+
+存储预测任务的元数据和配置。
+
+```sql
+CREATE TABLE prediction_tasks (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+
+    -- 预测的目标变量, e.g., {"type": "demand", "scope": "zonal", "zone_id": "zone_A"}
+    target_variable JSONB NOT NULL,
+
+    -- 使用的预测模型信息, e.g., {"type": "ml_model", "model_id": "demand_lstm_model_v2"}
+    prediction_model JSONB NOT NULL,
+
+    -- 预测的执行计划, e.g., {"type": "recurring", "cron_expression": "0 * * * *"}
+    prediction_schedule JSONB NOT NULL,
+
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `prediction_runs`
+
+记录每一次预测任务的执行。
+
+```sql
+CREATE TABLE prediction_runs (
+    id VARCHAR(255) PRIMARY KEY, -- 预测结果的唯一ID
+    task_id VARCHAR(255) NOT NULL,
+
+    generated_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(50) NOT NULL, -- 'success', 'failed'
+
+    -- 预测覆盖的时间范围
+    prediction_start_time TIMESTAMPTZ NOT NULL,
+    prediction_end_time TIMESTAMPTZ NOT NULL,
+
+    -- 相关的元数据，例如本次预测使用的模型版本、输入特征摘要等
+    metadata JSONB,
+
+    FOREIGN KEY (task_id) REFERENCES prediction_tasks(id)
+);
+```
+
+---
+
+## 第二部分: 结果数据 (时序模型)
+
+预测结果本身是时序数据，强烈建议使用时序数据库（TSDB）存储。
+
+### `prediction_values` (预测值)
+
+*   **Measurement:** `prediction_values`
+*   **Tags:**
+    *   `run_id`: 预测执行的ID，关联到`prediction_runs`表。
+    *   `task_id`: 预测任务的ID。
+*   **Fields:**
+    *   `value`: 预测值 (Float)。
+    *   `upper_bound`: 置信区间的上界 (Float, 可选)。
+    *   `lower_bound`: 置信区间的下界 (Float, 可选)。
+*   **Timestamp:** 预测点对应的时间戳。
+*   **示例 (Line Protocol):**
+    ```
+    # 第一行数据
+    prediction_values,run_id=pred_res_1678886400,task_id=pred_zonal_demand_24h value=120.5,upper_bound=128.0,lower_bound=113.0 1678890000000000000
+    # 第二行数据 (1小时后)
+    prediction_values,run_id=pred_res_1678886400,task_id=pred_zonal_demand_24h value=125.8,upper_bound=133.2,lower_bound=118.4 1678893600000000000
+    ```
+
+### 设计说明
+
+*   **配置与实例分离**: `prediction_tasks` 表定义了一个预测“应该如何”运行，而 `prediction_runs` 表记录了每一次实际的运行实例。这种设计清晰地分离了配置与历史记录。
+*   **元数据与数据分离**: 关系型的 `prediction_runs` 表存储了每次预测的元数据（何时运行、是否成功、覆盖范围等），而海量的时序数据点则交由更适合的TSDB来存储。通过 `run_id` 可以将两者关联起来，实现高效的查询。例如，可以先在关系型数据库中查询“过去一周所有成功的预测运行”，获得它们的 `run_id` 列表，然后再到TSDB中查询这些 `run_id` 对应的具体时序数据。

--- a/docs/water_system/data_models/07_scheduling_datamodel.md
+++ b/docs/water_system/data_models/07_scheduling_datamodel.md
@@ -1,0 +1,80 @@
+# 7. 调度 (Scheduling) - 数据模型
+
+本篇文档详细描述了与“优化调度”功能相关的核心数据模型。该模型主要用于存储调度任务的配置，以及每次优化运行后生成的控制计划。
+
+## ER图 (实体关系图)
+
+```
+[scheduling_tasks] 1--* [control_schedules]
+```
+
+## 表结构定义 (SQL DDL)
+
+### `scheduling_tasks`
+
+存储优化调度任务的配置信息。
+
+```sql
+CREATE TABLE scheduling_tasks (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    target_simulation_model_id VARCHAR(255) NOT NULL,
+
+    -- 可被控制的设备列表
+    control_variables JSONB NOT NULL,
+    -- e.g., [{"element_type": "pump", "element_id": "pump_A1", "control_type": "status"}]
+
+    -- 优化的目标函数
+    objective_function JSONB NOT NULL,
+    -- e.g., {"type": "minimize_cost", "cost_components": ["energy_cost", "maintenance_cost"]}
+
+    -- 必须满足的约束条件
+    constraints JSONB NOT NULL,
+    -- e.g., [{"type": "node_pressure", "node_id": "n_critical", "min_pressure": 22.0}]
+
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (target_simulation_model_id) REFERENCES simulations(id)
+);
+```
+
+### `control_schedules`
+
+存储优化调度任务的执行结果，即具体的控制计划。
+
+```sql
+CREATE TABLE control_schedules (
+    id VARCHAR(255) PRIMARY KEY,
+    task_id VARCHAR(255) NOT NULL,
+
+    generated_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(50) NOT NULL, -- 'success', 'failed_no_solution'
+
+    -- 该计划所基于的输入预测ID
+    based_on_prediction_run_id VARCHAR(255),
+
+    -- 计划覆盖的时间范围
+    schedule_start_time TIMESTAMPTZ NOT NULL,
+    schedule_end_time TIMESTAMPTZ NOT NULL,
+
+    -- 详细的控制计划，使用JSONB存储
+    -- 结构: {"pump_A1": {"status": [1,1,0,...]}, "valve_V3": {"setting": [28.0, 28.0, ...]}}
+    control_plan JSONB,
+
+    -- 预期的成本和KPI
+    expected_cost NUMERIC,
+    expected_kpis JSONB,
+
+    FOREIGN KEY (task_id) REFERENCES scheduling_tasks(id),
+    FOREIGN KEY (based_on_prediction_run_id) REFERENCES prediction_runs(id)
+);
+
+-- 为了快速查找某个任务的历史调度计划，创建索引
+CREATE INDEX idx_schedules_task_id ON control_schedules (task_id);
+```
+
+### 设计说明
+
+*   **JSONB的广泛使用**: 在 `scheduling_tasks` 表中，`control_variables`, `objective_function`, 和 `constraints` 都是半结构化的复杂数据。使用 `JSONB` 类型可以非常方便地存储这些灵活的配置，而无需创建大量关联表，大大简化了模型。
+*   **结果的完整性**: `control_schedules` 表不仅存储了最终的 `control_plan`，还记录了它是基于哪个预测 (`based_on_prediction_run_id`) 生成的，以及预期的成本和KPI。这为后续的“计划-实际”对比分析提供了完整的数据链条。
+*   **关系型模型的适用性**: 与时序数据不同，调度计划是离散的、结构化的，其生成频率不高（例如，每小时或每天一次）。因此，使用传统的关系型数据库来存储是完全合适的，并且便于进行复杂的查询和关联。

--- a/docs/water_system/data_models/08_testing_datamodel.md
+++ b/docs/water_system/data_models/08_testing_datamodel.md
@@ -1,0 +1,106 @@
+# 8. 测试 (Testing) - 数据模型
+
+本篇文档详细描述了与“自动化测试”功能相关的核心数据模型。该模型用于定义测试套件、测试用例，并记录每次测试的执行结果。
+
+## ER图 (实体关系图)
+
+```
+[test_suites] 1--* [test_cases]
+[test_suites] 1--* [test_runs]
+[test_runs] 1--* [test_case_results]
+[test_cases] 1--* [test_case_results]
+```
+
+## 表结构定义 (SQL DDL)
+
+### `test_suites`
+
+存储测试套件的定义。
+
+```sql
+CREATE TABLE test_suites (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+
+    -- 测试运行的环境配置
+    -- e.g., {"type": "staging", "endpoints": {"prediction_service": "..."}}
+    execution_environment JSONB,
+
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### `test_cases`
+
+存储组成测试套件的每个独立的测试用例。
+
+```sql
+CREATE TABLE test_cases (
+    id VARCHAR(255) PRIMARY KEY,
+    suite_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+
+    -- 测试用例的执行步骤和断言，使用JSONB存储
+    -- e.g., {"steps": [...], "assertions": [...]}
+    definition JSONB NOT NULL,
+
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (suite_id) REFERENCES test_suites(id)
+);
+```
+
+### `test_runs`
+
+记录测试套件的每一次执行。
+
+```sql
+CREATE TABLE test_runs (
+    id BIGSERIAL PRIMARY KEY,
+    suite_id VARCHAR(255) NOT NULL,
+
+    triggered_at TIMESTAMPTZ NOT NULL,
+    duration_ms INTEGER,
+
+    status VARCHAR(50) NOT NULL, -- 'passed', 'failed', 'running', 'error'
+
+    -- 本次运行的概要信息
+    -- e.g., {"total": 10, "passed": 9, "failed": 1}
+    summary JSONB,
+
+    -- 触发者信息 (e.g., 'CI/CD pipeline', 'user:jules')
+    triggered_by VARCHAR(255),
+
+    FOREIGN KEY (suite_id) REFERENCES test_suites(id)
+);
+```
+
+### `test_case_results`
+
+存储在一次测试运行中，每个测试用例的具体结果。
+
+```sql
+CREATE TABLE test_case_results (
+    id BIGSERIAL PRIMARY KEY,
+    run_id BIGINT NOT NULL,
+    case_id VARCHAR(255) NOT NULL,
+
+    status VARCHAR(50) NOT NULL, -- 'passed', 'failed', 'skipped'
+    duration_ms INTEGER,
+
+    -- 如果测试失败，存储失败原因和相关日志
+    failure_reason TEXT,
+    logs JSONB,
+
+    FOREIGN KEY (run_id) REFERENCES test_runs(id),
+    FOREIGN KEY (case_id) REFERENCES test_cases(id),
+    UNIQUE (run_id, case_id)
+);
+```
+
+### 设计说明
+
+*   **定义与执行分离**: `test_suites` 和 `test_cases` 表负责存储测试的“定义”，而 `test_runs` 和 `test_case_results` 负责存储测试的“执行历史”。这种分离使得测试用例的维护和版本控制变得清晰，同时可以完整地追溯每一次运行的结果。
+*   **结构化结果**: 将 `summary` 和 `logs` 存储为 `JSONB` 格式，可以在关系型数据库中方便地存储结构化的测试产出，便于后续的查询和分析，例如，可以查询“所有失败日志中包含特定错误信息的测试用例”。


### PR DESCRIPTION
This commit adds a new set of documents detailing the data models for each core service of the water system application.

A new `docs/water_system/data_models` directory has been created. For each service (Simulation, Twinning, Diagnosis, etc.), a markdown file has been added that describes a potential data persistence strategy, using a mix of SQL DDL and time-series database concepts.

This provides a deeper layer of technical documentation, moving from the API and conceptual layers to the data storage layer. The main README has been updated to link to these new documents.