### PR TITLE
docs: Add detailed documentation for PhysicalIOAgent in Chinese

### DIFF
--- a/docs/water_system/03_agents/05_physical_io_agent.md
+++ b/docs/water_system/03_agents/05_physical_io_agent.md
@@ -1,162 +1,100 @@
-# 05. Physical IO Agent (`PhysicalIOAgent`)
+# 05. 物理IO智能体 (`PhysicalIOAgent`)
 
-## Overview
+## 概述
 
-The `PhysicalIOAgent` acts as the crucial interface layer between the digital control agents and the physical world (or, in this simulation, the digital representation of the physical world). It simulates the behavior of hardware components like sensors and actuators that are part of a real-world Supervisory Control and Data Acquisition (SCADA) system.
+`PhysicalIOAgent` 是连接数字控制智能体与物理世界（或其模拟环境）的关键接口层。它旨在模拟真实世界中监控与数据采集（SCADA）系统里的硬件组件，如传感器和执行器。
 
-Its primary role is to bridge the gap between high-level control commands and the low-level physical state changes, and to provide realistic sensor feedback to the rest of the system.
+其核心角色是作为一座桥梁，将上层智能体发出的高级控制指令，转化为对物理实体的直接状态改变；同时，将物理世界的“真实”状态，以带有模拟噪声的传感器数据的形式，反馈给系统中的其他智能体。
 
-## Key Responsibilities
+## 核心职责
 
-1.  **Simulating Sensors**: It reads the "true" state from the physical model objects (e.g., the water level in a `Canal`), optionally adds random noise to simulate sensor inaccuracy, and publishes this data onto the `MessageBus` for other agents to consume.
-2.  **Simulating Actuators**: It subscribes to specific "action" topics on the `MessageBus`. When a message with a control command is received (e.g., "set gate opening to 0.5m"), it translates this command into a direct state change on the corresponding physical model object (e.g., setting the `target_opening` attribute of a `Gate` object).
+1.  **模拟传感器 (Sensing)**: 从物理模型对象（如 `Canal`）读取“真值”状态，选择性地加入高斯噪声以模拟传感器的不精确性，然后将处理后的数据发布到 `MessageBus`，供其他智能体使用。
+2.  **模拟执行器 (Actuating)**: 订阅 `MessageBus` 上的特定“动作”主题。当收到控制指令（如“设置闸门开度为0.5米”）时，它会将该指令转化为对相应物理模型对象属性的直接修改（例如，设置 `Gate` 对象的 `target_opening` 属性）。
 
-## Configuration
+## 配置
 
-The `PhysicalIOAgent` is initialized with the following parameters:
+`PhysicalIOAgent` 通过以下参数进行初始化：
 
--   `agent_id` (str): A unique identifier for the agent.
--   `message_bus` (MessageBus): An instance of the system's message bus.
--   `sensors_config` (dict): A dictionary defining the configuration for all sensors managed by this agent.
--   `actuators_config` (dict): A dictionary defining the configuration for all actuators managed by this agent.
+-   `agent_id` (str): 智能体的唯一标识符。
+-   `message_bus` (MessageBus): 系统消息总线的实例。
+-   `sensors_config` (dict): 定义此智能体管理的所有传感器的配置。
+-   `actuators_config` (dict): 定义此智能体管理的所有执行器的配置。
 
 ### `sensors_config`
 
-The keys of this dictionary are unique names for each sensor. The value is another dictionary with the following keys:
+该字典的键是每个传感器的唯一名称，值是包含以下键的另一字典：
 
--   `obj` (PhysicalObjectInterface): The actual physical object instance to read from (e.g., a `Canal` or `Reservoir` object).
--   `state_key` (str): The key to use when looking up the value from the object's state dictionary (returned by `get_state()`).
--   `topic` (str): The `MessageBus` topic on which to publish the sensor readings.
--   `noise_std` (float, optional): The standard deviation of the Gaussian noise to be added to the true value. Defaults to `0.0`.
+-   `obj` (PhysicalObjectInterface): 需要读取状态的物理对象实例（如 `Canal` 或 `Reservoir` 对象）。
+-   `state_key` (str): 从物理对象的 `get_state()` 方法返回的状态字典中，用于查找目标值的键。
+-   `topic` (str): 用于发布传感器读数的 `MessageBus` 主题。
+-   `noise_std` (float, optional): 添加到真值上的高斯噪声的标准差。默认为 `0.0`。
 
-**Example:**
-
+**示例:**
 ```python
 sensors_config = {
     'canal_level_sensor': {
-        'obj': upstream_canal,          # The canal object to monitor
-        'state_key': 'water_level',     # Read the 'water_level' from its state
-        'topic': 'state.canal.level',   # Publish to this topic
-        'noise_std': 0.02               # Add noise with a stddev of 0.02m
+        'obj': upstream_canal,          # 需要监控的渠池对象
+        'state_key': 'water_level',     # 从其状态中读取 'water_level'
+        'topic': 'state.canal.level',   # 发布到此主题
+        'noise_std': 0.02               # 添加标准差为 0.02 米的噪声
     }
 }
 ```
 
 ### `actuators_config`
 
-The keys of this dictionary are unique names for each actuator. The value is another dictionary with the following keys:
+该字典的键是每个执行器的唯一名称，值是包含以下键的另一字典：
 
--   `obj` (PhysicalObjectInterface): The actual physical object instance to control (e.g., a `Gate` or `Pump` object).
--   `target_attr` (str): The name of the attribute on the physical object that the agent should set as the target state (e.g., `target_opening`). The physical object's `step` method is responsible for moving from its current state towards this target state.
--   `topic` (str): The `MessageBus` topic to which this actuator listens for commands.
--   `control_key` (str): The key to look for in the incoming message's payload to find the desired control value.
+-   `obj` (PhysicalObjectInterface): 需要控制的物理对象实例（如 `Gate` 或 `Pump` 对象）。
+-   `target_attr` (str): 物理对象上需要被智能体设置的目标状态属性名（如 `target_opening`）。物理对象自身的 `step` 方法负责使其当前状态向此目标状态演化。
+-   `topic` (str): 执行器监听控制指令的 `MessageBus` 主题。
+-   `control_key` (str): 在收到的指令消息体中，用于查找控制值的键。
 
-**Example:**
-
+**示例:**
 ```python
 actuators_config = {
     'gate_actuator': {
-        'obj': control_gate,                # The gate object to control
-        'target_attr': 'target_opening',    # Set the 'target_opening' attribute on the gate
-        'topic': 'action.gate.opening',     # Listen on this topic for commands
-        'control_key': 'target_opening'     # The command message will contain this key
+        'obj': control_gate,                # 需要控制的闸门对象
+        'target_attr': 'target_opening',    # 设置该对象的 'target_opening' 属性
+        'topic': 'action.gate.opening',     # 在此主题上监听指令
+        'control_key': 'target_opening'     # 指令消息中将包含此键
     }
 }
 ```
 
-## Operation
+## 与`SimulationHarness`和`OntologySimulationAgent`的关系
 
-### Sensing (Publishing Data)
+在 `core_lib` 架构中，`PhysicalIOAgent` 的角色和定位与“世界”的驱动方式密切相关。理解它与 `SimulationHarness` 和 `OntologySimulationAgent` 的关系至关重要。
 
-The sensing operation is triggered by calling the agent's `run(current_time)` method at each simulation step. For each configured sensor, the agent:
-1.  Calls the `get_state()` method on the associated physical object.
-2.  Retrieves the true value using the `state_key`.
-3.  Generates a random noise value from a normal distribution (`mean=0`, `std=noise_std`).
-4.  Adds the noise to the true value.
-5.  Publishes a message to the specified `topic`.
+`SimulationHarness` 和 `OntologySimulationAgent` 代表了两种**不同且互斥**的仿真设计哲学：
 
-The published message is a dictionary with the following structure:
-```json
-{
-    "<state_key>": <noisy_value>,
-    "timestamp": <current_time>
-}
-```
-For example: `{'water_level': 1.513, 'timestamp': 10.0}`.
+### 1. 模块化架构: `SimulationHarness` + 物理模型 + `PhysicalIOAgent`
 
-### Actuating (Subscribing to Commands)
+在这种模式下，系统由多个独立的、可组合的模块构成：
+-   **`SimulationHarness`**: 扮演“世界引擎”的角色。它管理仿真时钟，并按顺序驱动一个两阶段（智能体阶段 -> 物理阶段）的循环。
+-   **物理模型 (`Gate`, `Canal` 等)**: 是被动的、包含自身物理逻辑的独立对象。它们的 `step()` 方法由 `SimulationHarness` 在物理阶段调用。
+-   **`PhysicalIOAgent`**: 在此架构中，它**是必需的**。
+    -   在“智能体阶段”，`PhysicalIOAgent` 的 `run()` 方法被调用，它从物理模型中读取状态，并发布到消息总线。
+    -   它异步地监听来自其他控制智能体的指令，并更新物理模型的目标属性（如 `target_opening`）。
+    -   它充当了被动的物理世界和主动的智能体世界之间的“I/O驱动程序”。
 
-During initialization, the `PhysicalIOAgent` automatically subscribes to the topics defined in its `actuators_config`. When a message arrives on one of these topics, the agent's internal callback is triggered. The callback:
-1.  Retrieves the control value from the message payload using the `control_key`.
-2.  Uses `setattr()` to update the attribute named `target_attr` on the associated physical object with this value.
+这个架构非常灵活，允许开发者通过YAML配置自由组合不同的物理组件和智能体，来构建任意复杂的系统。
 
-For example, if a message `{'target_opening': 0.75}` is published to the `action.gate.opening` topic, the agent will execute the equivalent of `control_gate.target_opening = 0.75`. The `Gate` object's own `step` method is then responsible for gradually changing its actual opening to meet this new target.
+### 2. 一体化架构: `OntologySimulationAgent` + 控制智能体
 
-## Example Usage
+在这种模式下，整个物理世界被封装在一个单一的、高保真的智能体中：
+-   **`OntologySimulationAgent`**: 它本身就是“物理世界”。其内部硬编码了物理状态、水动力学逻辑、执行器行为和传感器噪声。它在一个方法（如 `run_step()`）内完成了物理演化和数据发布的全部工作。
+-   **`PhysicalIOAgent`**: 在此架构中**完全不需要**。`OntologySimulationAgent` 已经承担了`PhysicalIOAgent`的全部职责（模拟传感器并发布数据）以及所有物理模型的职责。
 
-The following example demonstrates how to set up and run a `PhysicalIOAgent` to monitor a canal's water level and control a gate.
+这个架构的目的是提供一个**标准、可复现的测试环境**（就像一个“精装样板房”），用于测试和验证其他独立智能体（如一个新的PID控制器或一个预测算法）的性能。
 
-```python
-import time
-from core_lib.physical_objects.canal import Canal
-from core_lib.physical_objects.gate import Gate
-from core_lib.central_coordination.collaboration.message_bus import MessageBus
-from core_lib.local_agents.io.physical_io_agent import PhysicalIOAgent
+### 总结
 
-# 1. Initialize Physical Components and Message Bus
-bus = MessageBus()
-# Note: Physical objects require proper initialization with parameters.
-# upstream_canal = Canal(name="upstream_canal", ...)
-# control_gate = Gate(name="control_gate", ...)
+| 架构模式 | `SimulationHarness` 模式 | `OntologySimulationAgent` 模式 |
+| :--- | :--- | :--- |
+| **核心** | `SimulationHarness` (世界引擎) | `OntologySimulationAgent` (世界本身) |
+| **物理** | 独立的被动对象 (`Gate`, `Canal`) | 硬编码在 `OntologySimulationAgent` 内部 |
+| **`PhysicalIOAgent`角色** | **必需的**，作为物理层和智能体层之间的I/O桥梁 | **不需要**，其功能已由 `OntologySimulationAgent` 实现 |
+| **适用场景** | 构建、仿真和研究**任意结构**的复杂水系统 | 在**标准、固定**的环境中测试单个智能体的性能 |
 
-
-# 2. Define topics
-STATE_TOPIC = "state/canal/level"
-ACTION_TOPIC = "action/gate/opening"
-
-# 3. Configure and create the PhysicalIOAgent
-# This assumes 'upstream_canal' and 'control_gate' are initialized objects.
-# io_agent = PhysicalIOAgent(
-#     agent_id="io_agent_1",
-#     message_bus=bus,
-#     sensors_config={
-#         'canal_level_sensor': {
-#             'obj': upstream_canal,
-#             'state_key': 'water_level',
-#             'topic': STATE_TOPIC,
-#             'noise_std': 0.02
-#         }
-#     },
-#     actuators_config={
-#         'gate_actuator': {
-#             'obj': control_gate,
-#             'target_attr': 'target_opening',
-#             'topic': ACTION_TOPIC,
-#             'control_key': 'target_opening'
-#         }
-#     }
-# )
-
-# 4. Set up a listener to see the agent's output
-def print_sensor_data(message):
-    print(f"Received sensor data: {message}")
-bus.subscribe(STATE_TOPIC, print_sensor_data)
-
-# 5. Simulation Loop
-# dt = 1.0
-# for t in range(20):
-#     # In a real scenario, another agent would publish this command.
-#     if t == 5:
-#         print("\n>>> Sending command to open gate to 0.5m\n")
-#         bus.publish(ACTION_TOPIC, {'target_opening': 0.5})
-
-#     # The IO Agent reads sensors and publishes data
-#     io_agent.run(current_time=t)
-
-#     # The physical models evolve
-#     # (gate moves towards its target, canal water level changes)
-#     control_gate.step(...)
-#     upstream_canal.step(...)
-
-#     time.sleep(0.1)
-```
+因此，您会根据您的任务目标选择其中一种架构，而`PhysicalIOAgent`仅在第一种模块化架构中扮演核心角色。


### PR DESCRIPTION
This commit adds a comprehensive documentation file for the `PhysicalIOAgent`.

The new document is written in Chinese and covers:
- The agent's core responsibilities (simulating sensors and actuators).
- Detailed configuration options for `sensors_config` and `actuators_config`.
- A new section explaining the agent's role within the `SimulationHarness` architecture and its relationship to the alternative `OntologySimulationAgent` architecture.

This also includes updates to `AGENT_ARCHITECTURE.md` with a more descriptive summary and to `docs/water_system/README.md` to make the new document discoverable.