### PR TITLE
docs: Clarify control_key in PhysicalIOAgent example

### DIFF
--- a/docs/water_system/03_agents/05_physical_io_agent.md
+++ b/docs/water_system/03_agents/05_physical_io_agent.md
@@ -57,7 +57,7 @@ actuators_config = {
         'obj': control_gate,                # 需要控制的闸门对象
         'target_attr': 'target_opening',    # 设置该对象的 'target_opening' 属性
         'topic': 'action.gate.opening',     # 在此主题上监听指令
-        'control_key': 'target_opening'     # 指令消息中将包含此键
+        'control_key': 'control_signal'     # 指令消息中用于查找控制值的键
     }
 }
 ```


### PR DESCRIPTION
The example for `actuators_config` in the `PhysicalIOAgent` documentation was slightly confusing. It used the same value (`target_opening`) for both `target_attr` and `control_key`.

This change updates the `control_key` in the example to `control_signal`, which is clearer and aligns with the example in the source code's docstring. This better illustrates the purpose of the `control_key` as the key used to look up the control value from an incoming message payload.