### PR TITLE
feat(frontend): Implement interactive modeler for phase 2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,13 +8,20 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@types/file-saver": "^2.0.7",
+        "@types/js-yaml": "^4.0.9",
+        "@types/uuid": "^10.0.0",
         "antd": "^5.27.1",
         "axios": "^1.11.0",
+        "file-saver": "^2.0.5",
+        "js-yaml": "^4.1.0",
+        "jszip": "^3.10.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
         "reactflow": "^11.11.4",
         "recharts": "^3.1.2",
+        "uuid": "^11.1.0",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -2481,10 +2488,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.7.tgz",
+      "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2518,6 +2537,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3073,7 +3098,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -3365,6 +3389,12 @@
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4129,6 +4159,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4445,6 +4481,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
@@ -4491,6 +4533,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -4541,6 +4589,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4559,7 +4613,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4664,6 +4717,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4686,6 +4751,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/locate-path": {
@@ -4923,6 +4997,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5082,6 +5162,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5849,6 +5935,21 @@
         "react-dom": ">=17"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.2.tgz",
@@ -6009,6 +6110,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6058,6 +6165,12 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -6113,6 +6226,15 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-convert": {
       "version": "0.2.1",
@@ -6476,6 +6598,25 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,20 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@types/file-saver": "^2.0.7",
+    "@types/js-yaml": "^4.0.9",
+    "@types/uuid": "^10.0.0",
     "antd": "^5.27.1",
     "axios": "^1.11.0",
+    "file-saver": "^2.0.5",
+    "js-yaml": "^4.1.0",
+    "jszip": "^3.10.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
     "reactflow": "^11.11.4",
     "recharts": "^3.1.2",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Routes, Route, useNavigate, useLocation, Navigate } from 'react-router-dom';
-import { Layout, Menu } from 'antd';
+import { Layout, Menu, Button, Space } from 'antd';
+import { useProjectStore } from './store/projectStore';
+import { exportProjectAsZip } from './utils/project-exporter';
 import ModelingPage from './pages/ModelingPage';
 import SimulationPage from './pages/SimulationPage';
 import ProjectLoader from './components/ProjectLoader';
@@ -8,8 +10,13 @@ import ProjectLoader from './components/ProjectLoader';
 const { Header, Content } = Layout;
 
 const App: React.FC = () => {
+  const { projectConfig } = useProjectStore();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const handleExport = () => {
+    exportProjectAsZip(projectConfig);
+  };
 
   const handleMenuClick = (e: { key: string }) => {
     navigate(e.key);
@@ -37,7 +44,12 @@ const App: React.FC = () => {
             style={{ lineHeight: '64px' }}
           />
         </div>
-        <ProjectLoader />
+        <Space>
+          <ProjectLoader />
+          <Button type="primary" onClick={handleExport} disabled={!projectConfig}>
+            Export Project
+          </Button>
+        </Space>
       </Header>
       <Content style={{ padding: '24px' }}>
         <Routes>

--- a/frontend/src/components/ParameterEditor.tsx
+++ b/frontend/src/components/ParameterEditor.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect, ChangeEvent } from 'react';
+import { Card, Form, Input, Typography, Empty } from 'antd';
+import type { Node, Edge } from 'reactflow';
+import { useProjectStore } from '../store/projectStore';
+
+const { Title } = Typography;
+
+interface ParameterEditorProps {
+  element: Node | Edge | null;
+}
+
+const ParameterEditor: React.FC<ParameterEditorProps> = ({ element }) => {
+  const { updateElementData } = useProjectStore();
+  const [formData, setFormData] = useState<any>({});
+
+  useEffect(() => {
+    // Update form data when a new element is selected
+    setFormData(element?.data || {});
+  }, [element]);
+
+  if (!element) {
+    return <p>Click on a node or edge to see its parameters.</p>;
+  }
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev: any) => ({ ...prev, [name]: value }));
+  };
+
+  const handleInputBlur = () => {
+    // On blur, update the central store
+    updateElementData(element.id, formData);
+  };
+
+  // Render a form based on the element's data properties
+  const renderFormItems = () => {
+    const data = element.data || {};
+    return Object.entries(data).map(([key, value]) => {
+      // Make some fields read-only
+      if (key === 'label' || key === 'class' || key === '_id') {
+        return null;
+      }
+
+      // For nested objects like 'parameters', we can handle them differently if needed.
+      // For now, we'll just show them as stringified JSON.
+      const isObject = typeof value === 'object' && value !== null;
+      const displayValue = isObject ? JSON.stringify(value, null, 2) : value;
+
+      return (
+        <Form.Item label={key} key={key}>
+          <Input
+            name={key}
+            value={formData[key] ?? ''}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+            readOnly={isObject} // Make object fields read-only for now
+          />
+        </Form.Item>
+      );
+    }).filter(Boolean); // Filter out null entries
+  };
+
+  return (
+    <div>
+      <Title level={5}>Editing: {element.data.name || element.id}</Title>
+      <Form layout="vertical">
+        {renderFormItems()}
+      </Form>
+    </div>
+  );
+};
+
+export default ParameterEditor;

--- a/frontend/src/pages/ModelingPage.test.tsx
+++ b/frontend/src/pages/ModelingPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock('reactflow', () => ({
   Controls: () => <div>Controls</div>,
   MiniMap: () => <div>MiniMap</div>,
   Background: () => <div>Background</div>,
+  ReactFlowProvider: ({ children }) => <div>{children}</div>,
 }));
 
 describe('ModelingPage', () => {
@@ -68,8 +69,10 @@ describe('ModelingPage', () => {
     render(<ModelingPage />);
 
     expect(screen.getByText('Component Library')).toBeInTheDocument();
-    expect(screen.getByText('reservoir')).toBeInTheDocument();
-    expect(screen.getByText('gate')).toBeInTheDocument();
+    // Check for the new static component labels
+    expect(screen.getByText('Reservoir')).toBeInTheDocument();
+    expect(screen.getByText('Gate')).toBeInTheDocument();
+    expect(screen.getByText('Valve')).toBeInTheDocument();
 
     expect(screen.getByTestId('react-flow')).toBeInTheDocument();
 

--- a/frontend/src/pages/ModelingPage.tsx
+++ b/frontend/src/pages/ModelingPage.tsx
@@ -1,14 +1,42 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef, useCallback, DragEvent } from 'react';
 import { useProjectStore } from '../store/projectStore';
-import { Empty, Spin, Card, List } from 'antd';
-import ReactFlow, { MiniMap, Controls, Background, Node, Edge } from 'reactflow';
+import { Empty, Spin, Card, List, message } from 'antd';
+import ReactFlow, {
+  MiniMap,
+  Controls,
+  Background,
+  Node,
+  Edge,
+  ReactFlowProvider, // Import ReactFlowProvider
+  ReactFlowInstance,
+  Connection,
+} from 'reactflow';
 import 'reactflow/dist/style.css';
+import { v4 as uuidv4 } from 'uuid';
 
 import { transformToFlowData } from '../utils/flow-transformer';
+import { isValidConnection as validateConnection } from '../utils/connection-validator';
+import ParameterEditor from '../components/ParameterEditor';
 
-const ModelingPage: React.FC = () => {
-  const { projectConfig, isLoading, error } = useProjectStore();
+// Define a list of components that can be dragged from the library
+const availableComponents = [
+  { label: 'Reservoir', class: 'core_lib.physical_objects.reservoir.Reservoir' },
+  { label: 'Gate', class: 'core_lib.physical_objects.gate.Gate' },
+  { label: 'Valve', class: 'core_lib.physical_objects.valve.Valve' },
+  { label: 'Pump', class: 'core_lib.physical_objects.pump.Pump' },
+  { label: 'Pipe', class: 'core_lib.physical_objects.pipe.Pipe' },
+];
+
+const onDragStart = (event: DragEvent, componentClass: string) => {
+  event.dataTransfer.setData('application/reactflow', componentClass);
+  event.dataTransfer.effectAllowed = 'move';
+};
+
+const ModelingPageContent: React.FC = () => {
+  const { projectConfig, isLoading, error, addComponent, deleteElements, addConnection } = useProjectStore();
   const [selectedElement, setSelectedElement] = useState<Node | Edge | null>(null);
+  const reactFlowWrapper = useRef<HTMLDivElement>(null);
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null);
 
   const { nodes, edges } = useMemo(
     () => (projectConfig ? transformToFlowData(projectConfig) : { nodes: [], edges: [] }),
@@ -22,6 +50,64 @@ const ModelingPage: React.FC = () => {
   const onEdgeClick = (_event: React.MouseEvent, edge: Edge) => {
     setSelectedElement(edge);
   };
+
+  const onNodesDelete = useCallback((deleted: Node[]) => {
+    deleteElements({ nodes: deleted, edges: [] });
+  }, [deleteElements]);
+
+  const onEdgesDelete = useCallback((deleted: Edge[]) => {
+    deleteElements({ nodes: [], edges: deleted });
+  }, [deleteElements]);
+
+  const onConnect = useCallback((connection: Connection) => {
+    if (validateConnection(connection, nodes, edges)) {
+      addConnection({ source: connection.source, target: connection.target });
+    } else {
+      message.error('This connection is not allowed.');
+    }
+  }, [addConnection, nodes, edges]);
+
+  const isValidConnection = (connection: Connection) => validateConnection(connection, nodes, edges);
+
+  const onDragOver = useCallback((event: DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: DragEvent) => {
+      event.preventDefault();
+
+      if (!reactFlowInstance || !reactFlowWrapper.current) {
+        return;
+      }
+
+      const componentClass = event.dataTransfer.getData('application/reactflow');
+      if (!componentClass) {
+        return;
+      }
+
+      const position = reactFlowInstance.screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      const componentName = componentClass.split('.').pop() ?? 'Component';
+      const newNodeId = `${componentName}_${uuidv4().substring(0, 4)}`;
+
+      const newComponent = {
+        id: newNodeId,
+        class: componentClass,
+        name: newNodeId,
+        // Add default parameters based on component type later if needed
+        initial_state: {},
+        parameters: {},
+      };
+
+      addComponent(newComponent);
+    },
+    [reactFlowInstance, addComponent]
+  );
 
   if (isLoading) {
     return (
@@ -39,25 +125,38 @@ const ModelingPage: React.FC = () => {
     return <Empty description="No project loaded. Please select an example from the header." />;
   }
 
-  const componentTypes = projectConfig.components ? Object.keys(projectConfig.components) : [];
-
   return (
     <div style={{ display: 'flex', height: 'calc(100vh - 112px)', gap: '16px' }}>
       {/* Left Panel: Component Library */}
       <Card title="Component Library" style={{ width: '20%' }}>
         <List
-          dataSource={componentTypes}
-          renderItem={item => <List.Item>{item}</List.Item>}
+          dataSource={availableComponents}
+          renderItem={item => (
+            <List.Item
+              onDragStart={(event) => onDragStart(event, item.class)}
+              draggable
+              style={{ cursor: 'grab', border: '1px solid #f0f0f0', padding: '8px', marginBottom: '8px', borderRadius: '4px' }}
+            >
+              {item.label}
+            </List.Item>
+          )}
         />
       </Card>
 
       {/* Center Panel: Canvas */}
-      <div style={{ flex: 1, border: '1px solid #f0f0f0' }}>
+      <div style={{ flex: 1, border: '1px solid #f0f0f0' }} ref={reactFlowWrapper}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
           onNodeClick={onNodeClick}
           onEdgeClick={onEdgeClick}
+          onNodesDelete={onNodesDelete}
+          onEdgesDelete={onEdgesDelete}
+          onConnect={onConnect}
+          isValidConnection={isValidConnection}
+          onInit={setReactFlowInstance}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
           fitView
         >
           <Controls />
@@ -67,17 +166,19 @@ const ModelingPage: React.FC = () => {
       </div>
 
       {/* Right Panel: Parameters */}
-      <Card title="Parameters" style={{ width: '25%' }}>
-        {selectedElement ? (
-          <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-            {JSON.stringify(selectedElement.data, null, 2)}
-          </pre>
-        ) : (
-          <p>Click on a node or edge to see its parameters.</p>
-        )}
+      <Card title="Parameters" style={{ width: '25%', overflowY: 'auto' }}>
+        <ParameterEditor element={selectedElement} />
       </Card>
     </div>
   );
 };
+
+// Wrap ModelingPage with ReactFlowProvider
+const ModelingPage: React.FC = () => (
+  <ReactFlowProvider>
+    <ModelingPageContent />
+  </ReactFlowProvider>
+);
+
 
 export default ModelingPage;

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
+import type { Node, Edge } from 'reactflow';
 
 // In a real app, this would be in a .env file
 const API_BASE_URL = 'http://localhost:8000/api';
@@ -16,6 +18,10 @@ interface ProjectState {
   error: string | null;
   fetchExampleList: () => Promise<void>;
   loadProject: (examplePath: string) => Promise<void>;
+  addComponent: (component: any) => void;
+  deleteElements: (params: { nodes: Pick<Node, 'id'>[], edges: Pick<Edge, 'id'>[] }) => void;
+  addConnection: (connection: { source: string | null; target: string | null }) => void;
+  updateElementData: (elementId: string, newData: any) => void;
 }
 
 export const useProjectStore = create<ProjectState>((set) => ({
@@ -40,14 +46,119 @@ export const useProjectStore = create<ProjectState>((set) => ({
   loadProject: async (examplePath: string) => {
     set({ isLoading: true, error: null, projectConfig: null, selectedExamplePath: examplePath });
     try {
-      // Axios handles URL encoding for path segments automatically.
       const response = await axios.get<ProjectConfig>(`${API_BASE_URL}/examples/${examplePath}`);
-      console.log('Received project config:', response.data); // <-- ADDED FOR DEBUGGING
-      set({ projectConfig: response.data, isLoading: false });
+      const projectConfig = response.data;
+
+      // Add unique IDs to connections for easier manipulation
+      if (projectConfig.topology && Array.isArray(projectConfig.topology.connections)) {
+        projectConfig.topology.connections.forEach((c: any) => {
+          if (!c._id) {
+            c._id = uuidv4();
+          }
+        });
+      }
+
+      console.log('Received project config:', projectConfig); // <-- ADDED FOR DEBUGGING
+      set({ projectConfig: projectConfig, isLoading: false });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'An unknown error occurred.';
       console.error(`Failed to load project '${examplePath}':`, error);
       set({ error: `Failed to load project: ${message}`, isLoading: false, selectedExamplePath: null });
     }
   },
+
+  addComponent: (component) =>
+    set((state) => {
+      if (!state.projectConfig || !Array.isArray(state.projectConfig.components)) {
+        console.error("Cannot add component: projectConfig or components array is not initialized.");
+        return {};
+      }
+
+      const newProjectConfig = {
+        ...state.projectConfig,
+        components: [...state.projectConfig.components, component],
+      };
+
+      return { projectConfig: newProjectConfig };
+    }),
+
+  deleteElements: ({ nodes, edges }) =>
+    set((state) => {
+      if (!state.projectConfig) return {};
+
+      const deletedNodeIds = new Set(nodes.map(n => n.id));
+      const deletedEdgeIds = new Set(edges.map(e => e.id));
+
+      const remainingComponents = state.projectConfig.components.filter(
+        (c: any) => !deletedNodeIds.has(c.id)
+      );
+
+      const remainingConnections = state.projectConfig.topology.connections.filter(
+        (c: any) => !deletedEdgeIds.has(c._id)
+      );
+
+      const newProjectConfig = {
+        ...state.projectConfig,
+        components: remainingComponents,
+        topology: {
+          ...state.projectConfig.topology,
+          connections: remainingConnections,
+        },
+      };
+
+      return { projectConfig: newProjectConfig };
+    }),
+
+  addConnection: (connection) =>
+    set((state) => {
+      if (!state.projectConfig || !state.projectConfig.topology || !Array.isArray(state.projectConfig.topology.connections)) {
+        console.error("Cannot add connection: projectConfig or topology is not correctly initialized.");
+        return {};
+      }
+
+      const newConnection = {
+        ...connection,
+        _id: uuidv4(),
+      };
+
+      const newProjectConfig = {
+        ...state.projectConfig,
+        topology: {
+          ...state.projectConfig.topology,
+          connections: [...state.projectConfig.topology.connections, newConnection],
+        },
+      };
+
+      return { projectConfig: newProjectConfig };
+    }),
+
+  updateElementData: (elementId, newData) =>
+    set((state) => {
+      if (!state.projectConfig) return {};
+
+      const newComponents = state.projectConfig.components.map((c: any) => {
+        if (c.id === elementId) {
+          return { ...c, ...newData };
+        }
+        return c;
+      });
+
+      const newConnections = state.projectConfig.topology.connections.map((c: any) => {
+        if (c._id === elementId) {
+          return { ...c, ...newData };
+        }
+        return c;
+      });
+
+      return {
+        projectConfig: {
+          ...state.projectConfig,
+          components: newComponents,
+          topology: {
+            ...state.projectConfig.topology,
+            connections: newConnections,
+          },
+        },
+      };
+    }),
 }));

--- a/frontend/src/utils/connection-validator.ts
+++ b/frontend/src/utils/connection-validator.ts
@@ -1,0 +1,71 @@
+import { Connection, Edge, Node } from 'reactflow';
+
+// Define the port configuration for each component class.
+// This is a frontend assumption for now and should ideally be driven by backend data.
+const portConfig: { [key: string]: { inputs: number; outputs: number } } = {
+  'core_lib.physical_objects.reservoir.Reservoir': { inputs: 0, outputs: 1 },
+  'core_lib.physical_objects.gate.Gate': { inputs: 1, outputs: 1 },
+  'core_lib.physical_objects.valve.Valve': { inputs: 1, outputs: 1 },
+  'core_lib.physical_objects.pump.Pump': { inputs: 1, outputs: 1 },
+  'core_lib.physical_objects.pipe.Pipe': { inputs: 1, outputs: 1 },
+  // Add other components as needed
+};
+
+/**
+ * Validates if a new connection is allowed based on node types and port availability.
+ * @param connection The connection being attempted.
+ * @param nodes The list of all nodes on the canvas.
+ * @param edges The list of all edges on the canvas.
+ * @returns boolean True if the connection is valid, false otherwise.
+ */
+export const isValidConnection = (
+  connection: Connection,
+  nodes: Node[],
+  edges: Edge[]
+): boolean => {
+  if (!connection.source || !connection.target) {
+    return false;
+  }
+
+  const sourceNode = nodes.find(node => node.id === connection.source);
+  const targetNode = nodes.find(node => node.id === connection.target);
+
+  if (!sourceNode || !targetNode) {
+    return false;
+  }
+
+  const sourceClass = sourceNode.data.class;
+  const targetClass = targetNode.data.class;
+
+  const sourcePortConfig = portConfig[sourceClass] || { inputs: 1, outputs: 1 }; // Default
+  const targetPortConfig = portConfig[targetClass] || { inputs: 1, outputs: 1 }; // Default
+
+  // Rule 1: Source node must have available outputs.
+  if (sourcePortConfig.outputs === 0) {
+    console.warn(`Connection failed: Source node ${sourceNode.id} has no outputs.`);
+    return false;
+  }
+
+  // Rule 2: Target node must have available inputs.
+  if (targetPortConfig.inputs === 0) {
+    console.warn(`Connection failed: Target node ${targetNode.id} has no inputs.`);
+    return false;
+  }
+
+  // Rule 3: Target input port cannot have more than one connection.
+  const existingConnectionsToTarget = edges.filter(
+    edge => edge.target === connection.target
+  );
+
+  if (existingConnectionsToTarget.length >= targetPortConfig.inputs) {
+    console.warn(`Connection failed: Target node ${targetNode.id} input is already full.`);
+    return false;
+  }
+
+  // Rule 4: Cannot connect a node to itself.
+  if (connection.source === connection.target) {
+    return false;
+  }
+
+  return true;
+};

--- a/frontend/src/utils/flow-transformer.ts
+++ b/frontend/src/utils/flow-transformer.ts
@@ -63,11 +63,11 @@ export const transformToFlowData = (projectConfig: ProjectConfig): { nodes: Node
     });
 
     if (projectConfig && projectConfig.topology && projectConfig.topology.connections) {
-      projectConfig.topology.connections.forEach((connection, index) => {
+      projectConfig.topology.connections.forEach((connection) => {
         if (!connection || !connection.source || !connection.target) return; // Skip invalid connections
 
         edges.push({
-          id: `e-${connection.source}-${connection.target}-${index}`,
+          id: connection._id, // Use the unique ID from the store
           source: connection.source,
           target: connection.target,
           data: { ...connection },

--- a/frontend/src/utils/project-exporter.ts
+++ b/frontend/src/utils/project-exporter.ts
@@ -1,0 +1,64 @@
+import JSZip from 'jszip';
+import { saveAs } from 'file-saver';
+import yaml from 'js-yaml';
+
+/**
+ * Takes the project configuration state and exports it as a zip file
+ * containing the relevant YAML configuration files.
+ *
+ * @param projectConfig The project configuration object from the Zustand store.
+ */
+export const exportProjectAsZip = async (projectConfig: any) => {
+  if (!projectConfig) {
+    console.error("Export failed: projectConfig is null.");
+    return;
+  }
+
+  try {
+    const zip = new JSZip();
+
+    // 1. Create components.yml
+    // The backend expects a list of components under a 'components' key.
+    // However, our internal state is just the list. We need to wrap it.
+    if (projectConfig.components) {
+      // We need to remove the internal '_id' from connections before exporting
+      const cleanComponents = projectConfig.components.map((c: any) => {
+        const { ...rest } = c;
+        // In the future, we might add internal state to components too.
+        // This is where we would clean it up.
+        return rest;
+      });
+      zip.file('components.yml', yaml.dump({ components: cleanComponents }));
+    }
+
+    // 2. Create topology.yml
+    if (projectConfig.topology) {
+       const cleanConnections = projectConfig.topology.connections.map((c: any) => {
+        const { _id, ...rest } = c; // Remove internal _id before saving
+        return rest;
+      });
+      const topologyData = {
+        ...projectConfig.topology,
+        connections: cleanConnections,
+      }
+      zip.file('topology.yml', yaml.dump(topologyData));
+    }
+
+    // 3. Create agents.yml (if it exists)
+    if (projectConfig.agents) {
+      zip.file('agents.yml', yaml.dump(projectConfig.agents));
+    }
+
+    // 4. Create other config files if they exist (e.g., config.yml, output.yml)
+    // For now, we are only handling the core files.
+
+    // Generate the zip file and trigger a download
+    const zipBlob = await zip.generateAsync({ type: 'blob' });
+    const projectName = projectConfig.name || 'project';
+    saveAs(zipBlob, `${projectName}.zip`);
+
+  } catch (error) {
+    console.error("Failed to export project:", error);
+    // Optionally, show a message to the user
+  }
+};


### PR DESCRIPTION
This commit introduces the full set of features for the interactive modeler as outlined in Phase 2 of the development plan. The static model viewer is now a fully interactive single-page application.

Key features implemented:
- **Drag-and-Drop Creation**: Users can drag components from a library to create nodes on the canvas.
- **Element Deletion**: Selected nodes and edges can be deleted.
- **Interactive Connections**: Edges can be drawn between nodes, with real-time frontend validation to prevent invalid connections.
- **Parameter Editing**: A new panel allows users to select any node or edge and edit its parameters.
- **Project Export**: A new "Export Project" button allows users to download their current model configuration as a .zip file containing the relevant YAML files.

The implementation includes:
- Extending the Zustand store with actions for all CRUD operations.
- Adding a `ParameterEditor` component for the editing panel.
- Adding `jszip`, `js-yaml`, and `file-saver` to handle the project export functionality.
- Fixing all related tests to ensure the application remains stable.