### PR TITLE
Allow threshold equality to pass in getting started example

### DIFF
--- a/examples/non_agent_based/01_getting_started/run_config.py
+++ b/examples/non_agent_based/01_getting_started/run_config.py
@@ -159,11 +159,11 @@ def analyze_results(harness, config):
     passed_tests = 0
     for metric, (value, threshold) in evaluations.items():
         label = metric.replace('_', ' ').title()
-        if value < threshold:
-            print(f"✓ PASS: {label} = {value:.4f} < {threshold}")
+        if value <= threshold:
+            print(f"✓ PASS: {label} = {value:.4f} ≤ {threshold}")
             passed_tests += 1
         else:
-            print(f"✗ FAIL: {label} = {value:.4f} ≥ {threshold}")
+            print(f"✗ FAIL: {label} = {value:.4f} > {threshold}")
 
     total_tests = len(evaluations)
     print(f"\n=== Overall Performance: {passed_tests}/{total_tests} tests passed ===")

--- a/examples/non_agent_based/01_getting_started/run_simulation.py
+++ b/examples/non_agent_based/01_getting_started/run_simulation.py
@@ -211,10 +211,10 @@ def run_getting_started_simulation():
     failures = []
     for metric, threshold in performance_limits.items():
         value = evaluation[metric]
-        if value < threshold:
-            print(f"✓ PASS: {metric.replace('_', ' ').title()} = {value:.4f} < {threshold}")
+        if value <= threshold:
+            print(f"✓ PASS: {metric.replace('_', ' ').title()} = {value:.4f} ≤ {threshold}")
         else:
-            print(f"✗ FAIL: {metric.replace('_', ' ').title()} = {value:.4f} ≥ {threshold}")
+            print(f"✗ FAIL: {metric.replace('_', ' ').title()} = {value:.4f} > {threshold}")
             failures.append(f"{metric}={value:.4f}")
 
     if failures:


### PR DESCRIPTION
## Summary
- treat performance metrics that meet their thresholds as passing in the getting-started script
- mirror the updated comparison and messaging in the configuration-driven runner

## Testing
- python examples/non_agent_based/01_getting_started/run_simulation.py
- python examples/non_agent_based/01_getting_started/run_config.py --config config.yml
- python run_unified_scenario.py examples/non_agent_based/01_getting_started/unified_config.yml
- python examples/run_universal_config.py --example non_agent_based_01_getting_started

------
https://chatgpt.com/codex/tasks/task_e_68ce6015284883309e27fb144f6be088