### PR TITLE
Ignore binary assets and node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,16 @@ venv.bak/
 /examples/generated_json/
 server.log
 test_pause_resume.py
+# Binary/media assets
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.bmp
+*.tif
+*.tiff
+*.ico
+
+# Front-end build artifacts
+node_modules/


### PR DESCRIPTION
## Summary
- add ignore rules for common binary image formats to avoid committing PNGs and other media assets
- ignore node_modules to prevent accidentally tracking front-end dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce6482bbf8833090aedb285bad5c59